### PR TITLE
Fix interop between Ruby 1.8 and 1.9

### DIFF
--- a/mco-1.2.x/security/x509.rb
+++ b/mco-1.2.x/security/x509.rb
@@ -21,6 +21,14 @@ module MCollective
     #   plugin.x509.server_cert = /etc/mcollective/server_cert.pem
 
     class X509 < Base
+      def initialize
+        super
+        @serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        if @serializer == 'yaml'
+          YAML::ENGINE.yamler= 'syck' if defined?(YAML::ENGINE)
+        end
+      end
+
 
       def decodemsg(msg)
         body = deserialize(msg.payload)
@@ -101,11 +109,9 @@ module MCollective
       private
       # Serializes a message using the configured encoder
       def serialize(msg)
-        serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        Log.debug("Serializing using #{@serializer}")
 
-        Log.debug("Serializing using #{serializer}")
-
-        case serializer
+        case @serializer
         when "yaml"
           return YAML.dump(msg)
         else
@@ -115,11 +121,9 @@ module MCollective
 
       # De-Serializes a message using the configured encoder
       def deserialize(msg)
-        serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        Log.debug("De-Serializing using #{@serializer}")
 
-        Log.debug("De-Serializing using #{serializer}")
-
-        case serializer
+        case @serializer
         when "yaml"
           return YAML.load(msg)
         else

--- a/mco-2.x/security/x509.rb
+++ b/mco-2.x/security/x509.rb
@@ -21,6 +21,13 @@ module MCollective
     #   plugin.x509.server_cert = /etc/mcollective/server_cert.pem
 
     class X509 < Base
+      def initialize
+        super
+        @serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        if @serializer == 'yaml'
+          YAML::ENGINE.yamler= 'syck' if defined?(YAML::ENGINE)
+        end
+      end
 
       def valid_callerid?(callerid)
         begin
@@ -113,11 +120,9 @@ module MCollective
       private
       # Serializes a message using the configured encoder
       def serialize(msg)
-        serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        Log.debug("Serializing using #{@serializer}")
 
-        Log.debug("Serializing using #{serializer}")
-
-        case serializer
+        case @serializer
         when "yaml"
           return YAML.dump(msg)
         else
@@ -127,11 +132,9 @@ module MCollective
 
       # De-Serializes a message using the configured encoder
       def deserialize(msg)
-        serializer = @config.pluginconf["x509.serializer"] || "marshal"
+        Log.debug("De-Serializing using #{@serializer}")
 
-        Log.debug("De-Serializing using #{serializer}")
-
-        case serializer
+        case @serializer
         when "yaml"
           return YAML.load(msg)
         else


### PR DESCRIPTION
I discovered an issue when using Ruby 1.9.3 on the client and 1.8.7 on the server - differences in YAML serialization mean the client generates a signature that the server considers to be invalid.

This change forces use of the 'syck' engine on Ruby 1.9, to match 1.8's behaviour.
