### PR TITLE
Fix YAML engine selection on Ruby 1.8

### DIFF
--- a/mco-2.x/security/x509.rb
+++ b/mco-2.x/security/x509.rb
@@ -30,7 +30,7 @@ module MCollective
           if RbConfig::CONFIG['MAJOR'] == '2'
             require 'syck'
           end
-          YAML::ENGINE.yamler = 'syck'
+          YAML::ENGINE.yamler = 'syck' if defined?(YAML::ENGINE)
         end
       end
 


### PR DESCRIPTION
This fixes a crashing bug running under ruby 1.8, where YAML::ENGINE is not defined. The syck engine is default
anyway, so we don't actually have to do anything here.
